### PR TITLE
Use Hash::needsRehash in HasAttributes::castAttributeAsHashedString instead of Hash::isHashed

### DIFF
--- a/src/Illuminate/Contracts/Hashing/Hasher.php
+++ b/src/Illuminate/Contracts/Hashing/Hasher.php
@@ -39,4 +39,12 @@ interface Hasher
      * @return bool
      */
     public function needsRehash($hashedValue, array $options = []);
+
+    /**
+     * Check if the given hash is acceptable for the hasher.
+     *
+     * @param  string  $hashedValue
+     * @return bool
+     */
+    public function isAcceptable($hashedValue);
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1316,7 +1316,7 @@ trait HasAttributes
      */
     protected function castAttributeAsHashedString($key, $value)
     {
-        return $value !== null && ! Hash::isHashed($value) ? Hash::make($value) : $value;
+        return $value !== null && Hash::needsRehash($value) ? Hash::make($value) : $value;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1316,7 +1316,7 @@ trait HasAttributes
      */
     protected function castAttributeAsHashedString($key, $value)
     {
-        return $value !== null && Hash::needsRehash($value) ? Hash::make($value) : $value;
+        return $value !== null && ! Hash::isAcceptable($value) ? Hash::make($value) : $value;
     }
 
     /**

--- a/src/Illuminate/Hashing/AbstractHasher.php
+++ b/src/Illuminate/Hashing/AbstractHasher.php
@@ -31,4 +31,15 @@ abstract class AbstractHasher
 
         return password_verify($value, $hashedValue);
     }
+
+    /**
+     * Check if the given hash is acceptable for the hasher.
+     *
+     * @param  string  $hashedValue
+     * @return bool
+     */
+    public function isAcceptable($hashedValue)
+    {
+        return method_exists($this, 'needsRehash') && ! $this->needsRehash($hashedValue);
+    }
 }

--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -145,6 +145,21 @@ class ArgonHasher extends AbstractHasher implements HasherContract
     }
 
     /**
+     * Check if the given hash is acceptable for the hasher.
+     *
+     * @param  string  $hashedValue
+     * @return bool
+     */
+    public function isAcceptable($hashedValue)
+    {
+        $info = $this->info($hashedValue);
+
+        return $info['algoName'] === $this->algorithm()
+            && $info['options']['memory_cost'] / $info['options']['threads'] <= 4 * 65536
+            && $info['options']['threads'] <= 16;
+    }
+
+    /**
      * Set the default password threads factor.
      *
      * @param  int  $threads

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -89,6 +89,19 @@ class BcryptHasher extends AbstractHasher implements HasherContract
     }
 
     /**
+     * Check if the given hash is acceptable for the hasher.
+     *
+     * @param  string  $hashedValue
+     * @return bool
+     */
+    public function isAcceptable($hashedValue)
+    {
+        $info = $this->info($hashedValue);
+
+        return $info['algoName'] === 'bcrypt' && $info['options']['cost'] <= 16;
+    }
+
+    /**
      * Set the default password work factor.
      *
      * @param  int  $rounds

--- a/src/Illuminate/Hashing/HashManager.php
+++ b/src/Illuminate/Hashing/HashManager.php
@@ -89,6 +89,17 @@ class HashManager extends Manager implements Hasher
     }
 
     /**
+     * Check if the given hash is acceptable for the hasher.
+     *
+     * @param  string  $hashedValue
+     * @return bool
+     */
+    public function isAcceptable($hashedValue)
+    {
+        return $this->driver()->isAcceptable($hashedValue);
+    }
+
+    /**
      * Determine if a given string is already hashed.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Facades/Hash.php
+++ b/src/Illuminate/Support/Facades/Hash.php
@@ -10,6 +10,7 @@ namespace Illuminate\Support\Facades;
  * @method static string make(string $value, array $options = [])
  * @method static bool check(string $value, string $hashedValue, array $options = [])
  * @method static bool needsRehash(string $hashedValue, array $options = [])
+ * @method static bool isAcceptable(string $hashedValue)
  * @method static bool isHashed(string $value)
  * @method static string getDefaultDriver()
  * @method static mixed driver(string|null $driver = null)

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -56,6 +56,10 @@ class HasherTest extends TestCase
         $this->assertSame('bcrypt', password_get_info($value)['algoName']);
         $this->assertGreaterThanOrEqual(12, password_get_info($value)['options']['cost']);
         $this->assertTrue($this->hashManager->isHashed($value));
+        $this->assertTrue($hasher->isAcceptable($value));
+        $this->assertFalse($hasher->isAcceptable('password'));
+        $this->assertFalse($hasher->isAcceptable('$2y$17$1iPpw8cxiw6.ijzD2Ry1mOvBMM2kPu6wayaIXWLMG5fhFX5ejCEa6'));
+        $this->assertFalse($hasher->isAcceptable('$argon2i$v=19$m=65536,t=4,p=1$eE4vbkhJTm54M0k4OU1LTw$C9JCrLeNkNHI1jWx3pBqpK2bTgFrtcVcIfARjCN0218'));
     }
 
     public function testBasicArgon2iHashing()
@@ -68,6 +72,12 @@ class HasherTest extends TestCase
         $this->assertTrue($hasher->needsRehash($value, ['threads' => 1]));
         $this->assertSame('argon2i', password_get_info($value)['algoName']);
         $this->assertTrue($this->hashManager->isHashed($value));
+        $this->assertTrue($hasher->isAcceptable($value));
+        $this->assertTrue($hasher->isAcceptable('$argon2i$v=19$m=4194304,t=4,p=16$c01ieWxxZWozSmtHTzd5Vw$y9hJhd9Ip28ZFbh4BEVpPYSA6n017UIBdPcuTVna4hw'));
+        $this->assertFalse($hasher->isAcceptable('password'));
+        $this->assertFalse($hasher->isAcceptable('$argon2i$v=19$m=4194304,t=4,p=8$Ri5lRGt5VFMvMEtiLkYxQg$sPuFc8V0SKB1gmOJXmqcXscTZ8Awdkihf7m0Y/bskSg'));
+        $this->assertFalse($hasher->isAcceptable('$argon2i$v=19$m=8388608,t=4,p=32$Z0JUVVFTMTBVRnZlRHhldQ$sQrSwO1zcTFOseS56GZOd27SR9c05YUXPK7Np+gJpv4'));
+        $this->assertFalse($hasher->isAcceptable('$2y$10$PCXl4nmz2z8vckcBFi2AQObDvYOIlNa99REfp0dQN/Hq7Lc1wA5qC'));
     }
 
     public function testBasicArgon2idHashing()
@@ -80,6 +90,12 @@ class HasherTest extends TestCase
         $this->assertTrue($hasher->needsRehash($value, ['threads' => 1]));
         $this->assertSame('argon2id', password_get_info($value)['algoName']);
         $this->assertTrue($this->hashManager->isHashed($value));
+        $this->assertTrue($hasher->isAcceptable($value));
+        $this->assertTrue($hasher->isAcceptable('$argon2id$v=19$m=4194304,t=4,p=16$WmJySGpROWJuMUJxZXQ5Rw$u96pRIoI4xsj+OfFoluc+iEng3jkDfuTFDIJOYbRml0'));
+        $this->assertFalse($hasher->isAcceptable('password'));
+        $this->assertFalse($hasher->isAcceptable('$argon2id$v=19$m=4194304,t=4,p=8$VmZWVE5Uc2xDbklQVlhBWA$59KcqVqTfDt4WjoFIQkFIuXQEZBuRN7+G/YR7BDb9i8'));
+        $this->assertFalse($hasher->isAcceptable('$argon2id$v=19$m=8388608,t=4,p=32$dVFMcDB4WWkvRU41bGtDMQ$q4Y/26s5RVLn3tInzMgh/jUKeoOj/BXINARKQsvvhC4'));
+        $this->assertFalse($hasher->isAcceptable('$2y$10$PCXl4nmz2z8vckcBFi2AQObDvYOIlNa99REfp0dQN/Hq7Lc1wA5qC'));
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelHashedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelHashedCastingTest.php
@@ -30,9 +30,9 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
 
     public function testHashed()
     {
-        $this->hasher->expects('needsRehash')
+        $this->hasher->expects('isAcceptable')
             ->with('this is a password')
-            ->andReturnTrue();
+            ->andReturnFalse();
 
         $this->hasher->expects('make')
             ->with('this is a password')
@@ -49,11 +49,11 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
         ]);
     }
 
-    public function testNotHashedIfAlreadyHashed()
+    public function testNotHashedIfAlreadyCorrectlyHashed()
     {
-        $this->hasher->expects('needsRehash')
+        $this->hasher->expects('isAcceptable')
             ->with('already-hashed-password')
-            ->andReturnFalse();
+            ->andReturnTrue();
 
         $subject = HashedCast::create([
             'password' => 'already-hashed-password',

--- a/tests/Integration/Database/EloquentModelHashedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelHashedCastingTest.php
@@ -30,9 +30,9 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
 
     public function testHashed()
     {
-        $this->hasher->expects('isHashed')
+        $this->hasher->expects('needsRehash')
             ->with('this is a password')
-            ->andReturnFalse();
+            ->andReturnTrue();
 
         $this->hasher->expects('make')
             ->with('this is a password')
@@ -51,9 +51,9 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
 
     public function testNotHashedIfAlreadyHashed()
     {
-        $this->hasher->expects('isHashed')
+        $this->hasher->expects('needsRehash')
             ->with('already-hashed-password')
-            ->andReturnTrue();
+            ->andReturnFalse();
 
         $subject = HashedCast::create([
             'password' => 'already-hashed-password',


### PR DESCRIPTION
Implementation of `hashed`cast fix. The fix is based on `Hash::needsRehash` which will check if the hash was generated with the same configurations as the default hasher. (https://www.php.net/manual/en/function.password-needs-rehash.php)

It will causes a breaking change, if the developer currently creates the User with `hashed` cast and modifying the configuration, for example :
```php
User::create([
    'password' => Hash::make($password, ['rounds' => 14])
]);
```
With this new implementation, the password will be hashed twice. The probability is, IMHO, quite low and the fix is quite easy as it only requires to drop the `hashed` cast. It should not be a problem as the developer already hashes the password by hand.

Unfortunately, this implementation also requires changes in the laravel/laravel project.

Indeed, the `User` declares `hasehd` cast  and `UserFactory` declares 
```php
'password' => '$2y$12$Z/vhVO3e.UXKaG11EWgxc.EL7uej3Pi1M0Pq0orF5cbFGtyVh0V3C', // password
```
To speed up tests, in `phpunit.xml`, environment variable `BCRYPT_ROUNDS` is overrided to `4`.

As model factories can be used in tests (rounds 4 by default) and seeders (rounds 12 by default), we cannot define a pre-hashed value because of a double hashing in tests.

Therefore, there only viable solution I can think of is to drop the pre-hashed value and define 
```php
'password' => Hash::make('password'),
```
This way, the hash will always be generated with the correct config and won't be double hashed.
Another solution would be to defined
```php
'password' => 'password',
```
and let the cast do its job.

It won't slow down too much the tests as the `BCRYPT_ROUNDS` is at its minimum.
Unfortunately, this change needs to be made on every project using `hashed` cast on user's password (and the other models/attributes using the cast).

@valorin You proposed to block if the rounds if more than X above the config value. I don't think it will fix that UserFactory issue  because of the difference between the config in the pre-hashed  value (12) and the config (4) during the tests.

I hope we could have a better idea to solve initial issue, at this time I don't...

@taylorotwell @valorin I wait for your reviews before targeting laravel/framework